### PR TITLE
CSP-744 CSP-656 fix filter and add shutter page

### DIFF
--- a/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Controllers/Onboarding/AreasOfInterestControllerTests/AreasOfInterestControllerAttributeTests.cs
+++ b/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Controllers/Onboarding/AreasOfInterestControllerTests/AreasOfInterestControllerAttributeTests.cs
@@ -1,7 +1,6 @@
 ﻿using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.ApprenticeAan.Web.Controllers.Onboarding;
-using SFA.DAS.ApprenticeAan.Web.Filters;
 
 namespace SFA.DAS.ApprenticeAan.Web.UnitTests.Controllers.Onboarding.AreasOfInterestControllerTests;
 
@@ -14,11 +13,5 @@ public class AreasOfInterestControllerAttributeTests
         typeof(AreasOfInterestController).Should().BeDecoratedWith<RouteAttribute>();
         typeof(AreasOfInterestController).Should().BeDecoratedWith<RouteAttribute>().Subject.Template.Should().Be("onboarding/areas-of-interest");
         typeof(AreasOfInterestController).Should().BeDecoratedWith<RouteAttribute>().Subject.Name.Should().Be("AreasOfInterest");
-    }
-
-    [Test]
-    public void Controller_HasRequiredSessionModelAttribute()
-    {
-        typeof(AreasOfInterestController).Should().BeDecoratedWith<RequiredSessionModelAttribute>();
     }
 }

--- a/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Controllers/Onboarding/BeforeYouStartControllerTests/BeforeYouStartControllerPostTests.cs
+++ b/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Controllers/Onboarding/BeforeYouStartControllerTests/BeforeYouStartControllerPostTests.cs
@@ -1,47 +1,21 @@
-﻿namespace SFA.DAS.ApprenticeAan.Web.UnitTests.Controllers.Onboarding.BeforeYouStartControllerTests;
+﻿using AutoFixture.NUnit3;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using SFA.DAS.ApprenticeAan.Web.Controllers.Onboarding;
+using SFA.DAS.ApprenticeAan.Web.Infrastructure;
+using SFA.DAS.Testing.AutoFixture;
+
+namespace SFA.DAS.ApprenticeAan.Web.UnitTests.Controllers.Onboarding.BeforeYouStartControllerTests;
 
 [TestFixture]
 public class BeforeYouStartControllerPostTests
 {
-    //[MoqAutoData]
-    //public async Task Post_SetsEmptyOnBoardingSessionModel(
-    //    [Frozen] Mock<ISessionService> sessionServiceMock,
-    //    [Greedy] BeforeYouStartController sut)
-    //{
-    //    var result = await sut.Post();
+    [MoqAutoData]
+    public void Post_SessionModel_RedirectsRouteToTermsAndConditions(
+         [Greedy] BeforeYouStartController sut)
+    {
+        var result = sut.Post();
 
-    //    sessionServiceMock.Verify(s => s.Set(It.Is<OnboardingSessionModel>(m => !m.HasAcceptedTermsAndConditions)));
-    //    result.As<RedirectToRouteResult>().RouteName.Should().Be("TermsAndConditions");
-    //}
-
-    //[MoqAutoData]
-    //public async Task Post_GetProfiles_UpdatesSessionModel(
-    //    [Frozen] Mock<ISessionService> sessionServiceMock,
-    //    [Frozen] Mock<IProfileService> profileServiceMock,
-    //    [Greedy] BeforeYouStartController sut,
-    //    List<Profile> profiles)
-    //{
-    //    const string userType = "apprentice";
-
-    //    profileServiceMock.Setup(s => s.GetProfilesByUserType(userType)).ReturnsAsync(profiles);
-
-    //    await sut.Post();
-
-    //    sessionServiceMock.Verify(s => s.Set(It.Is<OnboardingSessionModel>(n => n.ProfileData.Count == profiles.Count)));
-    // }
-
-    //[MoqAutoData]
-    //public async Task Post_SessionModel_RedirectsRouteToTermsAndConditions(
-    //     [Frozen] Mock<ISessionService> sessionServiceMock,
-    //     [Greedy] BeforeYouStartController sut)
-    //{
-    //    OnboardingSessionModel sessionModel = new();
-
-    //    sessionServiceMock.Setup(s => s.Get<OnboardingSessionModel>()).Returns(sessionModel);
-
-    //    var result = await sut.Post();
-
-    //    result.As<RedirectToRouteResult>().Should().NotBeNull();
-    //    result.As<RedirectToRouteResult>().RouteName.Should().Be(RouteNames.Onboarding.TermsAndConditions);
-    //}
+        result.As<RedirectToRouteResult>().RouteName.Should().Be(RouteNames.Onboarding.TermsAndConditions);
+    }
 }

--- a/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Controllers/Onboarding/BeforeYouStartControllerTests/BeforeYouStartControllerPostTests.cs
+++ b/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Controllers/Onboarding/BeforeYouStartControllerTests/BeforeYouStartControllerPostTests.cs
@@ -1,58 +1,47 @@
-﻿using AutoFixture.NUnit3;
-using FluentAssertions;
-using Microsoft.AspNetCore.Mvc;
-using Moq;
-using SFA.DAS.ApprenticeAan.Domain.Interfaces;
-using SFA.DAS.ApprenticeAan.Domain.OuterApi.Responses;
-using SFA.DAS.ApprenticeAan.Web.Controllers.Onboarding;
-using SFA.DAS.ApprenticeAan.Web.Infrastructure;
-using SFA.DAS.ApprenticeAan.Web.Models;
-using SFA.DAS.Testing.AutoFixture;
-
-namespace SFA.DAS.ApprenticeAan.Web.UnitTests.Controllers.Onboarding.BeforeYouStartControllerTests;
+﻿namespace SFA.DAS.ApprenticeAan.Web.UnitTests.Controllers.Onboarding.BeforeYouStartControllerTests;
 
 [TestFixture]
 public class BeforeYouStartControllerPostTests
 {
-    [MoqAutoData]
-    public async Task Post_SetsEmptyOnBoardingSessionModel(
-        [Frozen] Mock<ISessionService> sessionServiceMock,
-        [Greedy] BeforeYouStartController sut)
-    {
-        var result = await sut.Post();
+    //[MoqAutoData]
+    //public async Task Post_SetsEmptyOnBoardingSessionModel(
+    //    [Frozen] Mock<ISessionService> sessionServiceMock,
+    //    [Greedy] BeforeYouStartController sut)
+    //{
+    //    var result = await sut.Post();
 
-        sessionServiceMock.Verify(s => s.Set(It.Is<OnboardingSessionModel>(m => !m.HasAcceptedTermsAndConditions)));
-        result.As<RedirectToRouteResult>().RouteName.Should().Be("TermsAndConditions");
-    }
+    //    sessionServiceMock.Verify(s => s.Set(It.Is<OnboardingSessionModel>(m => !m.HasAcceptedTermsAndConditions)));
+    //    result.As<RedirectToRouteResult>().RouteName.Should().Be("TermsAndConditions");
+    //}
 
-    [MoqAutoData]
-    public async Task Post_GetProfiles_UpdatesSessionModel(
-        [Frozen] Mock<ISessionService> sessionServiceMock,
-        [Frozen] Mock<IProfileService> profileServiceMock,
-        [Greedy] BeforeYouStartController sut,
-        List<Profile> profiles)
-    {
-        const string userType = "apprentice";
+    //[MoqAutoData]
+    //public async Task Post_GetProfiles_UpdatesSessionModel(
+    //    [Frozen] Mock<ISessionService> sessionServiceMock,
+    //    [Frozen] Mock<IProfileService> profileServiceMock,
+    //    [Greedy] BeforeYouStartController sut,
+    //    List<Profile> profiles)
+    //{
+    //    const string userType = "apprentice";
 
-        profileServiceMock.Setup(s => s.GetProfilesByUserType(userType)).ReturnsAsync(profiles);
+    //    profileServiceMock.Setup(s => s.GetProfilesByUserType(userType)).ReturnsAsync(profiles);
 
-        await sut.Post();
+    //    await sut.Post();
 
-        sessionServiceMock.Verify(s => s.Set(It.Is<OnboardingSessionModel>(n => n.ProfileData.Count == profiles.Count)));
-     }
+    //    sessionServiceMock.Verify(s => s.Set(It.Is<OnboardingSessionModel>(n => n.ProfileData.Count == profiles.Count)));
+    // }
 
-    [MoqAutoData]
-    public async Task Post_SessionModel_RedirectsRouteToTermsAndConditions(
-         [Frozen] Mock<ISessionService> sessionServiceMock,
-         [Greedy] BeforeYouStartController sut)
-    {
-        OnboardingSessionModel sessionModel = new();
+    //[MoqAutoData]
+    //public async Task Post_SessionModel_RedirectsRouteToTermsAndConditions(
+    //     [Frozen] Mock<ISessionService> sessionServiceMock,
+    //     [Greedy] BeforeYouStartController sut)
+    //{
+    //    OnboardingSessionModel sessionModel = new();
 
-        sessionServiceMock.Setup(s => s.Get<OnboardingSessionModel>()).Returns(sessionModel);
+    //    sessionServiceMock.Setup(s => s.Get<OnboardingSessionModel>()).Returns(sessionModel);
 
-        var result = await sut.Post();
+    //    var result = await sut.Post();
 
-        result.As<RedirectToRouteResult>().Should().NotBeNull();
-        result.As<RedirectToRouteResult>().RouteName.Should().Be(RouteNames.Onboarding.TermsAndConditions);
-    }
+    //    result.As<RedirectToRouteResult>().Should().NotBeNull();
+    //    result.As<RedirectToRouteResult>().RouteName.Should().Be(RouteNames.Onboarding.TermsAndConditions);
+    //}
 }

--- a/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Controllers/Onboarding/CheckYourAnswersControllerTests/CheckYourAnswersControllerAttributeTests.cs
+++ b/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Controllers/Onboarding/CheckYourAnswersControllerTests/CheckYourAnswersControllerAttributeTests.cs
@@ -1,7 +1,6 @@
 ﻿using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.ApprenticeAan.Web.Controllers.Onboarding;
-using SFA.DAS.ApprenticeAan.Web.Filters;
 using SFA.DAS.ApprenticeAan.Web.Infrastructure;
 
 namespace SFA.DAS.ApprenticeAan.Web.UnitTests.Controllers.Onboarding.CheckYourAnswersControllerTests;
@@ -15,11 +14,5 @@ public class CheckYourAnswersControllerAttributeTests
         typeof(CheckYourAnswersController).Should().BeDecoratedWith<RouteAttribute>();
         typeof(CheckYourAnswersController).Should().BeDecoratedWith<RouteAttribute>().Subject.Template.Should().Be("onboarding/check-your-answers");
         typeof(CheckYourAnswersController).Should().BeDecoratedWith<RouteAttribute>().Subject.Name.Should().Be(RouteNames.Onboarding.CheckYourAnswers);
-    }
-
-    [Test]
-    public void Controller_HasRequiredSessionModelAttribute()
-    {
-        typeof(CheckYourAnswersController).Should().BeDecoratedWith<RequiredSessionModelAttribute>();
     }
 }

--- a/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Controllers/Onboarding/CheckYourAnswersControllerTests/CheckYourAnswersControllerGetTests.cs
+++ b/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Controllers/Onboarding/CheckYourAnswersControllerTests/CheckYourAnswersControllerGetTests.cs
@@ -19,11 +19,11 @@ public class CheckYourAnswersControllerGetTests
     [MoqAutoData]
     public void Get_ReturnsViewResult(
         [Frozen] Mock<ISessionService> sessionServiceMock,
-        [Greedy] CheckYourAnswersController sut,
-        OnboardingSessionModel sessionModel)
+        [Greedy] CheckYourAnswersController sut)
     {
-        var jobTitle = "Test Job Title";
         sut.AddUrlHelperMock().AddUrlForRoute(RouteNames.Onboarding.CurrentJobTitle);
+        var jobTitle = "Test Job Title";
+        OnboardingSessionModel sessionModel = new();
         sessionModel.ProfileData.Add(new ProfileModel { Id = ProfileDataId.JobTitle, Value = jobTitle });
         sessionServiceMock.Setup(s => s.Get<OnboardingSessionModel>()).Returns(sessionModel);
 

--- a/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Controllers/Onboarding/CurrentJobTitleControllerTests/CurrentJobTitleControllerAttributeTests.cs
+++ b/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Controllers/Onboarding/CurrentJobTitleControllerTests/CurrentJobTitleControllerAttributeTests.cs
@@ -1,7 +1,6 @@
 ﻿using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.ApprenticeAan.Web.Controllers.Onboarding;
-using SFA.DAS.ApprenticeAan.Web.Filters;
 using SFA.DAS.ApprenticeAan.Web.Infrastructure;
 
 namespace SFA.DAS.ApprenticeAan.Web.UnitTests.Controllers.Onboarding.CurrentJobTitleControllerTests;
@@ -15,11 +14,5 @@ public class CurrentJobTitleControllerAttributeTests
         typeof(CurrentJobTitleController).Should().BeDecoratedWith<RouteAttribute>();
         typeof(CurrentJobTitleController).Should().BeDecoratedWith<RouteAttribute>().Subject.Template.Should().Be("onboarding/current-job-title");
         typeof(CurrentJobTitleController).Should().BeDecoratedWith<RouteAttribute>().Subject.Name.Should().Be(RouteNames.Onboarding.CurrentJobTitle);
-    }
-
-    [Test]
-    public void Controller_HasRequiredSessionModelAttribute()
-    {
-        typeof(CurrentJobTitleController).Should().BeDecoratedWith<RequiredSessionModelAttribute>();
     }
 }

--- a/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Controllers/Onboarding/EmployerDetailsControllerTests/EmployerDetailsControllerAttributeTests.cs
+++ b/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Controllers/Onboarding/EmployerDetailsControllerTests/EmployerDetailsControllerAttributeTests.cs
@@ -1,9 +1,7 @@
 ﻿using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.ApprenticeAan.Web.Controllers.Onboarding;
-using SFA.DAS.ApprenticeAan.Web.Filters;
 using SFA.DAS.ApprenticeAan.Web.Infrastructure;
-using SFA.DAS.ApprenticeAan.Web.Models;
 
 namespace SFA.DAS.ApprenticeAan.Web.UnitTests.Controllers.Onboarding.EmployerDetailsControllerTests;
 
@@ -17,12 +15,5 @@ public class EmployerDetailsControllerAttributeTests
         typeof(EmployerDetailsController).Should().BeDecoratedWith<RouteAttribute>();
         typeof(EmployerDetailsController).Should().BeDecoratedWith<RouteAttribute>().Subject.Template.Should().Be("onboarding/employer-details");
         typeof(EmployerDetailsController).Should().BeDecoratedWith<RouteAttribute>().Subject.Name.Should().Be(RouteNames.Onboarding.EmployerDetails);
-    }
-
-    [Test]
-    public void Controller_HasRequiredSessionModelAttribute()
-    {
-        typeof(EmployerDetailsController).Should().BeDecoratedWith<RequiredSessionModelAttribute>();
-        typeof(EmployerDetailsController).Should().BeDecoratedWith<RequiredSessionModelAttribute>().Subject.ModelType.Name.Should().Be(nameof(OnboardingSessionModel));
     }
 }

--- a/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Controllers/Onboarding/EmployerSearchControllerTests/EmployerSearchControllerAttributeTests.cs
+++ b/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Controllers/Onboarding/EmployerSearchControllerTests/EmployerSearchControllerAttributeTests.cs
@@ -1,7 +1,6 @@
 ﻿using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.ApprenticeAan.Web.Controllers.Onboarding;
-using SFA.DAS.ApprenticeAan.Web.Filters;
 using SFA.DAS.ApprenticeAan.Web.Infrastructure;
 
 namespace SFA.DAS.ApprenticeAan.Web.UnitTests.Controllers.Onboarding.EmployerSearchControllerTests;
@@ -14,11 +13,5 @@ public class EmployerSearchControllerAttributeTests
         typeof(EmployerSearchController).Should().BeDecoratedWith<RouteAttribute>();
         typeof(EmployerSearchController).Should().BeDecoratedWith<RouteAttribute>().Subject.Template.Should().Be("onboarding/employer-search");
         typeof(EmployerSearchController).Should().BeDecoratedWith<RouteAttribute>().Subject.Name.Should().Be(RouteNames.Onboarding.EmployerSearch);
-    }
-
-    [Test]
-    public void Controller_HasRequiredSessionModelAttribute()
-    {
-        typeof(EmployerSearchController).Should().BeDecoratedWith<RequiredSessionModelAttribute>();
     }
 }

--- a/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Controllers/Onboarding/LineManagerControllerTests/LineManagerControllerAttributeTests.cs
+++ b/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Controllers/Onboarding/LineManagerControllerTests/LineManagerControllerAttributeTests.cs
@@ -1,8 +1,6 @@
 ﻿using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.ApprenticeAan.Web.Controllers.Onboarding;
-using SFA.DAS.ApprenticeAan.Web.Filters;
-using SFA.DAS.ApprenticeAan.Web.Models;
 
 namespace SFA.DAS.ApprenticeAan.Web.UnitTests.Controllers.Onboarding.LineManagerControllerTests;
 
@@ -15,12 +13,5 @@ public class LineManagerControllerAttributeTests
         typeof(LineManagerController).Should().BeDecoratedWith<RouteAttribute>();
         typeof(LineManagerController).Should().BeDecoratedWith<RouteAttribute>().Subject.Template.Should().Be("onboarding/line-manager");
         typeof(LineManagerController).Should().BeDecoratedWith<RouteAttribute>().Subject.Name.Should().Be("LineManager");
-    }
-
-    [Test]
-    public void Controller_HasRequiredSessionModelAttribute()
-    {
-        typeof(LineManagerController).Should().BeDecoratedWith<RequiredSessionModelAttribute>();
-        typeof(LineManagerController).Should().BeDecoratedWith<RequiredSessionModelAttribute>().Subject.ModelType.Name.Should().Be(nameof(OnboardingSessionModel));
     }
 }

--- a/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Controllers/Onboarding/LineManagerControllerTests/LineManagerControllerGetTests.cs
+++ b/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Controllers/Onboarding/LineManagerControllerTests/LineManagerControllerGetTests.cs
@@ -1,11 +1,10 @@
 ﻿using AutoFixture.NUnit3;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Moq;
-using SFA.DAS.ApprenticeAan.Domain.Interfaces;
 using SFA.DAS.ApprenticeAan.Web.Controllers.Onboarding;
 using SFA.DAS.ApprenticeAan.Web.Infrastructure;
-using SFA.DAS.ApprenticeAan.Web.Models;
 using SFA.DAS.ApprenticeAan.Web.Models.Onboarding;
 using SFA.DAS.ApprenticeAan.Web.UnitTests.TestHelpers;
 using SFA.DAS.Testing.AutoFixture;
@@ -16,43 +15,44 @@ namespace SFA.DAS.ApprenticeAan.Web.UnitTests.Controllers.Onboarding.LineManager
 public class LineManagerControllerGetTests
 {
     [MoqAutoData]
-    public void Get_ReturnsViewResult([Greedy] LineManagerController sut)
+    public void Get_ViewResult_RedirectsToStartOfJourney(
+       [Greedy] LineManagerController sut,
+       Mock<ITempDataDictionary> tempDataMock)
     {
+        tempDataMock.Setup(t => t.ContainsKey(TempDataKeys.HasSeenTermsAndConditions)).Returns(false);
+        sut.TempData = tempDataMock.Object;
         sut.AddUrlHelperMock();
+
         var result = sut.Get();
 
-        result.As<ViewResult>().Should().NotBeNull();
+        result.As<RedirectToRouteResult>().RouteName.Should().Be(RouteNames.Onboarding.BeforeYouStart);
     }
 
     [MoqAutoData]
-    public void Get_ViewResult_HasCorrectViewPath([Greedy] LineManagerController sut)
+    public void Get_ViewResult_ReturnsView(
+        [Greedy] LineManagerController sut,
+        Mock<ITempDataDictionary> tempDataMock)
     {
+        tempDataMock.Setup(t => t.ContainsKey(TempDataKeys.HasSeenTermsAndConditions)).Returns(true);
+        sut.TempData = tempDataMock.Object;
         sut.AddUrlHelperMock();
+
         var result = sut.Get();
 
         result.As<ViewResult>().ViewName.Should().Be(LineManagerController.ViewPath);
     }
 
     [MoqAutoData]
-    public void Get_ViewModel_HasBackLink([Greedy] LineManagerController sut)
+    public void Get_ViewModel_HasBackLink(
+        [Greedy] LineManagerController sut,
+        Mock<ITempDataDictionary> tempDataMock)
     {
+        tempDataMock.Setup(t => t.ContainsKey(TempDataKeys.HasSeenTermsAndConditions)).Returns(true);
+        sut.TempData = tempDataMock.Object;
         sut.AddUrlHelperMock().AddUrlForRoute(RouteNames.Onboarding.TermsAndConditions);
+
         var result = sut.Get();
 
         result.As<ViewResult>().Model.As<LineManagerViewModel>().BackLink.Should().Be(TestConstants.DefaultUrl);
-    }
-
-    [MoqAutoData]
-    public void Get_ViewModelHasEmployersApproval_RestoreFromSession(
-                        [Frozen] Mock<ISessionService> sessionServiceMock,
-                        OnboardingSessionModel sessionModel,
-                        [Greedy] LineManagerController sut)
-    {
-        sut.AddUrlHelperMock().AddUrlForRoute(RouteNames.Onboarding.TermsAndConditions);
-        sessionServiceMock.Setup(s => s.Get<OnboardingSessionModel>()).Returns(sessionModel);
-
-        var result = sut.Get();
-
-        result.As<ViewResult>().Model.As<LineManagerViewModel>().HasEmployersApproval.Should().Be(sessionModel.HasEmployersApproval);
     }
 }

--- a/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Controllers/Onboarding/LineManagerControllerTests/LineManagerControllerPostTests.cs
+++ b/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Controllers/Onboarding/LineManagerControllerTests/LineManagerControllerPostTests.cs
@@ -98,8 +98,7 @@ public class LineManagerControllerPostTests
         [Frozen] Mock<IValidator<LineManagerSubmitModel>> validatorMock,
         [Greedy] LineManagerController sut,
         Mock<ITempDataDictionary> tempDataMock,
-        LineManagerSubmitModel submitModel,
-        List<Profile> profiles)
+        LineManagerSubmitModel submitModel)
     {
         tempDataMock.Setup(t => t.ContainsKey(TempDataKeys.HasSeenTermsAndConditions)).Returns(true);
         sut.TempData = tempDataMock.Object;

--- a/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Controllers/Onboarding/LineManagerControllerTests/LineManagerControllerPostTests.cs
+++ b/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Controllers/Onboarding/LineManagerControllerTests/LineManagerControllerPostTests.cs
@@ -3,8 +3,11 @@ using FluentAssertions;
 using FluentValidation;
 using FluentValidation.Results;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Moq;
 using SFA.DAS.ApprenticeAan.Domain.Interfaces;
+using SFA.DAS.ApprenticeAan.Domain.OuterApi.Responses;
+using SFA.DAS.ApprenticeAan.Web.Configuration;
 using SFA.DAS.ApprenticeAan.Web.Controllers.Onboarding;
 using SFA.DAS.ApprenticeAan.Web.Infrastructure;
 using SFA.DAS.ApprenticeAan.Web.Models;
@@ -18,77 +21,94 @@ namespace SFA.DAS.ApprenticeAan.Web.UnitTests.Controllers.Onboarding.LineManager
 public class LineManagerControllerPostTests
 {
     [MoqAutoData]
-    public void Post_ModelStateIsInvalid_ReloadsViewWithValidationErrors(
+    public async Task Post_HasNotSeenTermsAndConditions_RedirectToTheStartOfTheJourney(
+        [Greedy] LineManagerController sut,
+        Mock<ITempDataDictionary> tempDataMock,
+        LineManagerSubmitModel submitModel)
+    {
+        tempDataMock.Setup(t => t.ContainsKey(TempDataKeys.HasSeenTermsAndConditions)).Returns(false);
+        sut.TempData = tempDataMock.Object;
+
+        var result = await sut.Post(submitModel);
+
+        result.As<RedirectToRouteResult>().RouteName.Should().Be(RouteNames.Onboarding.BeforeYouStart);
+    }
+
+    [MoqAutoData]
+    public async Task Post_ModelStateIsInvalid_ReloadsViewWithValidationErrors(
+        [Greedy] LineManagerController sut,
+        Mock<ITempDataDictionary> tempDataMock,
+        LineManagerSubmitModel submitModel,
+        string termsAndConditionsUrl)
+    {
+        tempDataMock.Setup(t => t.ContainsKey(TempDataKeys.HasSeenTermsAndConditions)).Returns(true);
+        sut.TempData = tempDataMock.Object;
+        sut.ModelState.AddModelError("key", "message");
+        sut.AddUrlHelperMock().AddUrlForRoute(RouteNames.Onboarding.TermsAndConditions, termsAndConditionsUrl);
+
+        var result = await sut.Post(submitModel);
+
+        result.As<ViewResult>().ViewName.Should().Be(LineManagerController.ViewPath);
+        result.As<ViewResult>().Model.As<LineManagerViewModel>().BackLink.Should().Be(termsAndConditionsUrl);
+    }
+
+    [MoqAutoData]
+    public async Task Post_DoesNotHaveLineManagersApproval_RedirectsToTheShutterPage(
+        [Frozen] ApplicationConfiguration applicationConfiguration,
+        [Frozen] Mock<IValidator<LineManagerSubmitModel>> validatorMock,
+        [Greedy] LineManagerController sut,
+        Mock<ITempDataDictionary> tempDataMock,
+        LineManagerSubmitModel submitModel)
+    {
+        tempDataMock.Setup(t => t.ContainsKey(TempDataKeys.HasSeenTermsAndConditions)).Returns(true);
+        sut.TempData = tempDataMock.Object;
+        submitModel.HasEmployersApproval = false;
+        validatorMock.Setup(v => v.Validate(submitModel)).Returns(new ValidationResult());
+
+        var result = await sut.Post(submitModel);
+
+        result.As<ViewResult>().ViewName.Should().Be(LineManagerController.ShutterPageViewPath);
+        result.As<ViewResult>().Model.As<ShutterPageViewModel>().ApprenticeHomeUrl.Should().Be(applicationConfiguration.ApplicationUrls.ApprenticeHomeUrl.ToString());
+    }
+
+    [MoqAutoData]
+    public async Task Post_HasSeenTermsAndHasLineManagerApproval_InitializesSessionModel(
+        [Frozen] Mock<IValidator<LineManagerSubmitModel>> validatorMock,
+        [Frozen] Mock<IProfileService> profileServiceMock,
         [Frozen] Mock<ISessionService> sessionServiceMock,
         [Greedy] LineManagerController sut,
-        [Frozen] LineManagerSubmitModel submitmodel)
+        Mock<ITempDataDictionary> tempDataMock,
+        LineManagerSubmitModel submitModel,
+        List<Profile> profiles)
     {
-        OnboardingSessionModel sessionModel = new();
-        sut.AddUrlHelperMock().AddUrlForRoute(RouteNames.Onboarding.TermsAndConditions);
+        tempDataMock.Setup(t => t.ContainsKey(TempDataKeys.HasSeenTermsAndConditions)).Returns(true);
+        sut.TempData = tempDataMock.Object;
+        submitModel.HasEmployersApproval = true;
+        validatorMock.Setup(v => v.Validate(submitModel)).Returns(new ValidationResult());
+        profileServiceMock.Setup(p => p.GetProfilesByUserType("apprentice")).ReturnsAsync(profiles);
 
-        sessionServiceMock.Setup(s => s.Get<OnboardingSessionModel>()).Returns(sessionModel);
+        await sut.Post(submitModel);
 
-        sut.ModelState.AddModelError("key", "message");
-
-        var result = sut.Post(submitmodel);
-
-        sut.ModelState.IsValid.Should().BeFalse();
-
-        sessionModel.HasEmployersApproval.Should().BeNull();
-
-        sessionServiceMock.Verify(s => s.Set(sessionModel));
-
-        result.As<ViewResult>().Should().NotBeNull();
-        result.As<ViewResult>().ViewName.Should().Be(LineManagerController.ViewPath);
-        result.As<ViewResult>().Model.As<LineManagerViewModel>().BackLink.Should().Be(TestConstants.DefaultUrl);
+        sessionServiceMock.Verify(s => s.Set(It.Is<OnboardingSessionModel>(m
+            => m.HasAcceptedTerms && m.ProfileData.Count == profiles.Count)));
     }
 
     [MoqAutoData]
-    public void Post_ModelStateIsValid_UpdatesSessionModel(
-        [Frozen] Mock<ISessionService> sessionServiceMock,
+    public async Task Post_HasSeenTermsAndHasLineManagerApproval_RedirectsToEmployerSearch(
         [Frozen] Mock<IValidator<LineManagerSubmitModel>> validatorMock,
-        [Frozen] LineManagerSubmitModel submitmodel,
-        [Greedy] LineManagerController sut)
+        [Greedy] LineManagerController sut,
+        Mock<ITempDataDictionary> tempDataMock,
+        LineManagerSubmitModel submitModel,
+        List<Profile> profiles)
     {
-        OnboardingSessionModel sessionModel = new();
-        ValidationResult validationResult = new();
+        tempDataMock.Setup(t => t.ContainsKey(TempDataKeys.HasSeenTermsAndConditions)).Returns(true);
+        sut.TempData = tempDataMock.Object;
+        submitModel.HasEmployersApproval = true;
+        validatorMock.Setup(v => v.Validate(submitModel)).Returns(new ValidationResult());
 
-        sut.AddUrlHelperMock().AddUrlForRoute(RouteNames.Onboarding.TermsAndConditions);
+        var result = await sut.Post(submitModel);
 
-        sessionServiceMock.Setup(s => s.Get<OnboardingSessionModel>()).Returns(sessionModel);
-        validatorMock.Setup(v => v.Validate(submitmodel)).Returns(validationResult);
-
-        sessionServiceMock.Object.Set(sessionModel);
-
-        sut.Post(submitmodel);
-
-        sessionServiceMock.Verify(s => s.Set(sessionModel));
-
-        sessionModel.HasEmployersApproval.Should().Be(submitmodel.HasEmployersApproval);
-
-        sut.ModelState.IsValid.Should().BeTrue();
-    }
-
-    [MoqAutoData]
-    public void Post_ModelStateIsValid_RedirectsToEmployerSearch(
-        [Frozen] Mock<ISessionService> sessionServiceMock,
-        [Frozen] Mock<IValidator<LineManagerSubmitModel>> validatorMock,
-        [Frozen] LineManagerSubmitModel submitmodel,
-        [Greedy] LineManagerController sut)
-    {
-        OnboardingSessionModel sessionModel = new();
-        ValidationResult validationResult = new();
-
-        sut.AddUrlHelperMock().AddUrlForRoute(RouteNames.Onboarding.TermsAndConditions);
-
-        sessionServiceMock.Setup(s => s.Get<OnboardingSessionModel>()).Returns(sessionModel);
-        validatorMock.Setup(v => v.Validate(submitmodel)).Returns(validationResult);
-
-        var result = sut.Post(submitmodel);
-
-        sut.ModelState.IsValid.Should().BeTrue();
-
-        result.As<RedirectToRouteResult>().Should().NotBeNull();
         result.As<RedirectToRouteResult>().RouteName.Should().Be(RouteNames.Onboarding.EmployerSearch);
     }
+
 }

--- a/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Controllers/Onboarding/PreviousEngagementControllerTests/PreviousEngagementControllerAttributeTests.cs
+++ b/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Controllers/Onboarding/PreviousEngagementControllerTests/PreviousEngagementControllerAttributeTests.cs
@@ -1,9 +1,7 @@
 ﻿using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.ApprenticeAan.Web.Controllers.Onboarding;
-using SFA.DAS.ApprenticeAan.Web.Filters;
 using SFA.DAS.ApprenticeAan.Web.Infrastructure;
-using SFA.DAS.ApprenticeAan.Web.Models;
 
 namespace SFA.DAS.ApprenticeAan.Web.UnitTests.Controllers.Onboarding.PreviousEngagementControllerTests;
 
@@ -16,12 +14,5 @@ public class PreviousEngagementControllerAttributeTests
         typeof(PreviousEngagementController).Should().BeDecoratedWith<RouteAttribute>();
         typeof(PreviousEngagementController).Should().BeDecoratedWith<RouteAttribute>().Subject.Template.Should().Be("onboarding/previous-engagement");
         typeof(PreviousEngagementController).Should().BeDecoratedWith<RouteAttribute>().Subject.Name.Should().Be(RouteNames.Onboarding.PreviousEngagement);
-    }
-
-    [Test]
-    public void Controller_HasRequiredSessionModelAttribute()
-    {
-        typeof(PreviousEngagementController).Should().BeDecoratedWith<RequiredSessionModelAttribute>();
-        typeof(PreviousEngagementController).Should().BeDecoratedWith<RequiredSessionModelAttribute>().Subject.ModelType.Name.Should().Be(nameof(OnboardingSessionModel));
     }
 }

--- a/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Controllers/Onboarding/PreviousEngagementControllerTests/PreviousEngagementControllerGetTests.cs
+++ b/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Controllers/Onboarding/PreviousEngagementControllerTests/PreviousEngagementControllerGetTests.cs
@@ -19,10 +19,10 @@ public class PreviousEngagementControllerGetTests
     [MoqAutoData]
     public void Get_ViewResult_SelectedYes_HasCorrectViewPath(
         [Frozen] Mock<ISessionService> sessionServiceMock,
-        OnboardingSessionModel sessionModel,
         [Greedy] PreviousEngagementController sut)
     {
         sut.AddUrlHelperMock();
+        OnboardingSessionModel sessionModel = new();
         sessionServiceMock.Setup(s => s.Get<OnboardingSessionModel>()).Returns(sessionModel);
         sessionModel.ProfileData.Add(new ProfileModel { Id = ProfileDataId.EngagedWithAPreviousAmbassadorInTheNetwork, Value = "True" });
 
@@ -34,12 +34,12 @@ public class PreviousEngagementControllerGetTests
     [MoqAutoData]
     public void Get_ViewResult_SelectedNo_HasCorrectViewPath(
         [Frozen] Mock<ISessionService> sessionServiceMock,
-        OnboardingSessionModel sessionModel,
         [Greedy] PreviousEngagementController sut)
     {
         sut.AddUrlHelperMock();
-        sessionServiceMock.Setup(s => s.Get<OnboardingSessionModel>()).Returns(sessionModel);
+        OnboardingSessionModel sessionModel = new();
         sessionModel.ProfileData.Add(new ProfileModel { Id = ProfileDataId.EngagedWithAPreviousAmbassadorInTheNetwork, Value = "False" });
+        sessionServiceMock.Setup(s => s.Get<OnboardingSessionModel>()).Returns(sessionModel);
 
         var result = sut.Get();
 

--- a/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Controllers/Onboarding/PreviousEngagementControllerTests/PreviousEngagementControllerGetTests.cs
+++ b/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Controllers/Onboarding/PreviousEngagementControllerTests/PreviousEngagementControllerGetTests.cs
@@ -49,12 +49,12 @@ public class PreviousEngagementControllerGetTests
     [MoqAutoData]
     public void Get_ViewModel_HasBackLink(
         [Frozen] Mock<ISessionService> sessionServiceMock,
-        OnboardingSessionModel sessionModel,
         [Greedy] PreviousEngagementController sut)
     {
+        OnboardingSessionModel sessionModel = new();
+        sessionModel.ProfileData.Add(new ProfileModel { Id = ProfileDataId.EngagedWithAPreviousAmbassadorInTheNetwork, Value = "True" });
         sut.AddUrlHelperMock().AddUrlForRoute(RouteNames.Onboarding.AreasOfInterest);
         sessionServiceMock.Setup(s => s.Get<OnboardingSessionModel>()).Returns(sessionModel);
-        sessionModel.ProfileData.Add(new ProfileModel { Id = ProfileDataId.EngagedWithAPreviousAmbassadorInTheNetwork, Value = "True" });
 
         var result = sut.Get();
 
@@ -63,9 +63,9 @@ public class PreviousEngagementControllerGetTests
 
     [MoqAutoData]
     public void Get_ViewModel_SelectedYes_RestoreFromSession(
-                        [Frozen] Mock<ISessionService> sessionServiceMock,
-                        OnboardingSessionModel sessionModel,
-                        [Greedy] PreviousEngagementController sut)
+        [Frozen] Mock<ISessionService> sessionServiceMock,
+        OnboardingSessionModel sessionModel,
+        [Greedy] PreviousEngagementController sut)
     {
         sut.AddUrlHelperMock().AddUrlForRoute(RouteNames.Onboarding.AreasOfInterest);
         sessionServiceMock.Setup(s => s.Get<OnboardingSessionModel>()).Returns(sessionModel);
@@ -78,9 +78,9 @@ public class PreviousEngagementControllerGetTests
 
     [MoqAutoData]
     public void Get_ViewModel_SelectedNo_RestoreFromSession(
-                    [Frozen] Mock<ISessionService> sessionServiceMock,
-                    OnboardingSessionModel sessionModel,
-                    [Greedy] PreviousEngagementController sut)
+        [Frozen] Mock<ISessionService> sessionServiceMock,
+        OnboardingSessionModel sessionModel,
+        [Greedy] PreviousEngagementController sut)
     {
         sut.AddUrlHelperMock().AddUrlForRoute(RouteNames.Onboarding.AreasOfInterest);
         sessionServiceMock.Setup(s => s.Get<OnboardingSessionModel>()).Returns(sessionModel);

--- a/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Controllers/Onboarding/ReasonToJoinControllerTests/ReasonToJoinControllerAttributeTests.cs
+++ b/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Controllers/Onboarding/ReasonToJoinControllerTests/ReasonToJoinControllerAttributeTests.cs
@@ -1,9 +1,7 @@
 ﻿using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.ApprenticeAan.Web.Controllers.Onboarding;
-using SFA.DAS.ApprenticeAan.Web.Filters;
 using SFA.DAS.ApprenticeAan.Web.Infrastructure;
-using SFA.DAS.ApprenticeAan.Web.Models;
 
 namespace SFA.DAS.ApprenticeAan.Web.UnitTests.Controllers.Onboarding.ReasonToJoinControllerTests;
 
@@ -16,12 +14,5 @@ public class ReasonToJoinControllerAttributeTests
         typeof(ReasonToJoinController).Should().BeDecoratedWith<RouteAttribute>();
         typeof(ReasonToJoinController).Should().BeDecoratedWith<RouteAttribute>().Subject.Template.Should().Be("onboarding/reason-to-join");
         typeof(ReasonToJoinController).Should().BeDecoratedWith<RouteAttribute>().Subject.Name.Should().Be(RouteNames.Onboarding.ReasonToJoin);
-    }
-
-    [Test]
-    public void Controller_HasRequiredSessionModelAttribute()
-    {
-        typeof(ReasonToJoinController).Should().BeDecoratedWith<RequiredSessionModelAttribute>();
-        typeof(ReasonToJoinController).Should().BeDecoratedWith<RequiredSessionModelAttribute>().Subject.ModelType.Name.Should().Be(nameof(OnboardingSessionModel));
     }
 }

--- a/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Controllers/Onboarding/RegionsControllerTests/RegionsControllerAttributeTests.cs
+++ b/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Controllers/Onboarding/RegionsControllerTests/RegionsControllerAttributeTests.cs
@@ -1,7 +1,6 @@
 ﻿using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.ApprenticeAan.Web.Controllers.Onboarding;
-using SFA.DAS.ApprenticeAan.Web.Filters;
 using SFA.DAS.ApprenticeAan.Web.Infrastructure;
 
 namespace SFA.DAS.ApprenticeAan.Web.UnitTests.Controllers.Onboarding.RegionsControllerTests;
@@ -15,11 +14,5 @@ public class RegionsControllerAttributeTests
         typeof(RegionsController).Should().BeDecoratedWith<RouteAttribute>();
         typeof(RegionsController).Should().BeDecoratedWith<RouteAttribute>().Subject.Template.Should().Be("onboarding/regions");
         typeof(RegionsController).Should().BeDecoratedWith<RouteAttribute>().Subject.Name.Should().Be(RouteNames.Onboarding.Regions);
-    }
-
-    [Test]
-    public void Controller_HasRequiredSessionModelAttribute()
-    {
-        typeof(RegionsController).Should().BeDecoratedWith<RequiredSessionModelAttribute>();
     }
 }

--- a/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Controllers/Onboarding/RegionsControllerTests/RegionsControllerPostTests.cs
+++ b/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Controllers/Onboarding/RegionsControllerTests/RegionsControllerPostTests.cs
@@ -47,7 +47,6 @@ public class RegionsControllerPostTests
         var result = await sut.Post(submitmodel);
 
         sessionServiceMock.Verify(s => s.Set(It.Is<OnboardingSessionModel>(m => m.RegionId == null)));
-        sessionServiceMock.Verify(s => s.Set(It.Is<OnboardingSessionModel>(m => !m.IsValid)));
         result.As<ViewResult>().Model.As<RegionsViewModel>().SelectedRegionId.Should().BeNull();
     }
 

--- a/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Controllers/Onboarding/TermsAndConditionsControllerTests/TermsAndConditionsControllerAttributeTests.cs
+++ b/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Controllers/Onboarding/TermsAndConditionsControllerTests/TermsAndConditionsControllerAttributeTests.cs
@@ -1,25 +1,17 @@
 ﻿using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.ApprenticeAan.Web.Controllers.Onboarding;
-using SFA.DAS.ApprenticeAan.Web.Filters;
 
-namespace SFA.DAS.ApprenticeAan.Web.UnitTests.Controllers.Onboarding.TermsAndConditionsControllerTests
+namespace SFA.DAS.ApprenticeAan.Web.UnitTests.Controllers.Onboarding.TermsAndConditionsControllerTests;
+
+[TestFixture]
+internal class TermsAndConditionsControllerAttributeTests
 {
-    [TestFixture]
-    internal class TermsAndConditionsControllerAttributeTests
+    [Test]
+    public void Controller_HasCorrectRouteAttribute()
     {
-        [Test]
-        public void Controller_HasCorrectRouteAttribute()
-        {
-            typeof(TermsAndConditionsController).Should().BeDecoratedWith<RouteAttribute>();
-            typeof(TermsAndConditionsController).Should().BeDecoratedWith<RouteAttribute>().Subject.Template.Should().Be("onboarding/terms-and-conditions");
-            typeof(TermsAndConditionsController).Should().BeDecoratedWith<RouteAttribute>().Subject.Name.Should().Be("TermsAndConditions");
-        }
-
-        [Test]
-        public void Controller_HasRequiredSessionModelAttribute()
-        {
-            typeof(TermsAndConditionsController).Should().BeDecoratedWith<RequiredSessionModelAttribute>();
-        }
+        typeof(TermsAndConditionsController).Should().BeDecoratedWith<RouteAttribute>();
+        typeof(TermsAndConditionsController).Should().BeDecoratedWith<RouteAttribute>().Subject.Template.Should().Be("onboarding/terms-and-conditions");
+        typeof(TermsAndConditionsController).Should().BeDecoratedWith<RouteAttribute>().Subject.Name.Should().Be("TermsAndConditions");
     }
 }

--- a/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Models/OnboardingSessionModelTests.cs
+++ b/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Models/OnboardingSessionModelTests.cs
@@ -7,50 +7,22 @@ namespace SFA.DAS.ApprenticeAan.Web.UnitTests.Models;
 [TestFixture]
 public class OnboardingSessionModelTests
 {
-    private static readonly object[] GetProfileData =
+
+    [Test]
+    public void IsValid_NoProfileData_ReturnsFalse()
     {
-        new object[] { new Guid("bf92480f-1ef6-4552-8a5e-35d7951213f9"), true, true, new List<ProfileModel>(), false },
+        OnboardingSessionModel sut = new() { HasAcceptedTerms = true };
 
-        new object[] { new Guid("bf92480f-1ef6-4552-8a5e-35d7951213f9"), true, true, new List<ProfileModel> { new ProfileModel() }, true },
-    };
-
-    [TestCaseSource(nameof(GetProfileData))]
-    public void IsValid_ProfileData_ChecksModelValidity(
-        Guid? apprenticeId, bool hasAcceptedTAndCs, bool? hasEmployersApproval,
-        List<ProfileModel> profileData, bool expectedResult)
-    {
-        var model = new OnboardingSessionModel()
-        {
-            HasAcceptedTermsAndConditions = hasAcceptedTAndCs,
-            HasEmployersApproval = hasEmployersApproval,
-        };
-        model.ApprenticeDetails.ApprenticeId = apprenticeId;
-        model.ProfileData = profileData;
-
-        var actualResult = model.IsValid;
-
-        Assert.That(actualResult, Is.EqualTo(expectedResult));
+        sut.IsValid.Should().BeFalse();
     }
 
-    [TestCase(null, true, true, false)]
-    [TestCase("00000000-0000-0000-0000-000000000000", true, true, false)]
-    [TestCase("bf92480f-1ef6-4552-8a5e-35d7951213f9", false, true, false)]
-    [TestCase("bf92480f-1ef6-4552-8a5e-35d7951213f9", true, false, false)]
-    [TestCase("bf92480f-1ef6-4552-8a5e-35d7951213f9", true, null, false)]
-    [TestCase("bf92480f-1ef6-4552-8a5e-35d7951213f9", true, true, true)]
-    public void IsValid_ChecksModelValidity(Guid? apprenticeId, bool hasAcceptedTAndCs, bool? hasEmployersApproval, bool expectedResult)
+    [Test]
+    [AutoData]
+    public void IsValid_HasNotAcceptedTerms_ReturnsFalse(List<ProfileModel> profileData)
     {
-        var model = new OnboardingSessionModel()
-        {
-            HasAcceptedTermsAndConditions = hasAcceptedTAndCs,
-            HasEmployersApproval = hasEmployersApproval,
-        };
-        model.ProfileData.Add(new ProfileModel());
-        model.ApprenticeDetails.ApprenticeId = apprenticeId;
+        OnboardingSessionModel sut = new() { HasAcceptedTerms = false, ProfileData = profileData };
 
-        var actualResult = model.IsValid;
-
-        Assert.That(actualResult, Is.EqualTo(expectedResult));
+        sut.IsValid.Should().BeFalse();
     }
 
     [Test]

--- a/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Validators/Onboarding/LineManagerSubmitModelValidatorTests.cs
+++ b/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Validators/Onboarding/LineManagerSubmitModelValidatorTests.cs
@@ -17,25 +17,5 @@ namespace SFA.DAS.ApprenticeAan.Web.UnitTests.Validators.Onboarding
 
             result.ShouldHaveValidationErrorFor(x => x.HasEmployersApproval).WithErrorMessage(LineManagerSubmitModelValidator.NoSelectionErrorMessage);
         }
-
-        [TestCase(true, true)]
-        [TestCase(false, false)]
-        [TestCase(null, false)]
-        public void HasEmployersApproval_Valid_NoErrors(bool? value, bool isValid)
-        {
-            var model = new LineManagerSubmitModel { HasEmployersApproval = value };
-            var sut = new LineManagerSubmitModelValidator();
-
-            var result = sut.TestValidate(model);
-
-            if (isValid)
-                result.ShouldNotHaveValidationErrorFor(c => c.HasEmployersApproval);
-
-            if (!isValid && value == null)
-                    result.ShouldHaveValidationErrorFor(c => c.HasEmployersApproval).WithErrorMessage(LineManagerSubmitModelValidator.NoSelectionErrorMessage);
-
-            if (!isValid && value == false)
-                result.ShouldHaveValidationErrorFor(c => c.HasEmployersApproval).WithErrorMessage(LineManagerSubmitModelValidator.NoApprovalErrorMessage);
-        }
     }
 }

--- a/src/SFA.DAS.ApprenticeAan.Web/Controllers/Onboarding/AreasOfInterestController.cs
+++ b/src/SFA.DAS.ApprenticeAan.Web/Controllers/Onboarding/AreasOfInterestController.cs
@@ -4,7 +4,6 @@ using FluentValidation.Results;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.ApprenticeAan.Domain.Interfaces;
-using SFA.DAS.ApprenticeAan.Web.Filters;
 using SFA.DAS.ApprenticeAan.Web.Infrastructure;
 using SFA.DAS.ApprenticeAan.Web.Models;
 using SFA.DAS.ApprenticeAan.Web.Models.Onboarding;
@@ -13,7 +12,6 @@ namespace SFA.DAS.ApprenticeAan.Web.Controllers.Onboarding;
 
 [Authorize]
 [Route("onboarding/areas-of-interest", Name = RouteNames.Onboarding.AreasOfInterest)]
-[RequiredSessionModel(typeof(OnboardingSessionModel))]
 public class AreasOfInterestController : Controller
 {
     public const string ViewPath = "~/Views/Onboarding/AreasOfInterest.cshtml";

--- a/src/SFA.DAS.ApprenticeAan.Web/Controllers/Onboarding/BeforeYouStartController.cs
+++ b/src/SFA.DAS.ApprenticeAan.Web/Controllers/Onboarding/BeforeYouStartController.cs
@@ -1,9 +1,7 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using SFA.DAS.ApprenticeAan.Domain.Interfaces;
 using SFA.DAS.ApprenticeAan.Web.Configuration;
 using SFA.DAS.ApprenticeAan.Web.Infrastructure;
-using SFA.DAS.ApprenticeAan.Web.Models;
 using SFA.DAS.ApprenticeAan.Web.Models.Onboarding;
 
 namespace SFA.DAS.ApprenticeAan.Web.Controllers.Onboarding;
@@ -15,13 +13,9 @@ public class BeforeYouStartController : Controller
     public const string ViewPath = "~/Views/Onboarding/BeforeYouStart.cshtml";
 
     private readonly ApplicationConfiguration _applicationConfiguration;
-    private readonly ISessionService _sessionService;
-    private readonly IProfileService _profileService;
 
-    public BeforeYouStartController(ISessionService sessionService, IProfileService profileService, ApplicationConfiguration applicationConfiguration)
+    public BeforeYouStartController(ApplicationConfiguration applicationConfiguration)
     {
-        _sessionService = sessionService;
-        _profileService = profileService;
         _applicationConfiguration = applicationConfiguration;
     }
 
@@ -36,14 +30,8 @@ public class BeforeYouStartController : Controller
     }
 
     [HttpPost]
-    public async Task<IActionResult> Post()
+    public IActionResult Post()
     {
-        var profiles = await _profileService.GetProfilesByUserType("apprentice");
-        OnboardingSessionModel sessionModel = new()
-        {
-            ProfileData = profiles.Select(p => (ProfileModel)p).ToList()
-        };
-        _sessionService.Set(sessionModel);
         return RedirectToRoute(RouteNames.Onboarding.TermsAndConditions);
     }
 }

--- a/src/SFA.DAS.ApprenticeAan.Web/Controllers/Onboarding/CheckYourAnswersController.cs
+++ b/src/SFA.DAS.ApprenticeAan.Web/Controllers/Onboarding/CheckYourAnswersController.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.ApprenticeAan.Domain.Interfaces;
-using SFA.DAS.ApprenticeAan.Web.Filters;
 using SFA.DAS.ApprenticeAan.Web.Infrastructure;
 using SFA.DAS.ApprenticeAan.Web.Models;
 using SFA.DAS.ApprenticeAan.Web.Models.Onboarding;
@@ -10,7 +9,6 @@ namespace SFA.DAS.ApprenticeAan.Web.Controllers.Onboarding;
 
 [Authorize]
 [Route("onboarding/check-your-answers", Name = RouteNames.Onboarding.CheckYourAnswers)]
-[RequiredSessionModel(typeof(OnboardingSessionModel))]
 public class CheckYourAnswersController : Controller
 {
     public const string ViewPath = "~/Views/Onboarding/CheckYourAnswers.cshtml";

--- a/src/SFA.DAS.ApprenticeAan.Web/Controllers/Onboarding/CurrentJobTitleController.cs
+++ b/src/SFA.DAS.ApprenticeAan.Web/Controllers/Onboarding/CurrentJobTitleController.cs
@@ -5,7 +5,6 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.ApprenticeAan.Domain.Constants;
 using SFA.DAS.ApprenticeAan.Domain.Interfaces;
-using SFA.DAS.ApprenticeAan.Web.Filters;
 using SFA.DAS.ApprenticeAan.Web.Infrastructure;
 using SFA.DAS.ApprenticeAan.Web.Models;
 using SFA.DAS.ApprenticeAan.Web.Models.Onboarding;
@@ -13,7 +12,6 @@ using SFA.DAS.ApprenticeAan.Web.Models.Onboarding;
 namespace SFA.DAS.ApprenticeAan.Web.Controllers.Onboarding;
 
 [Route("onboarding/current-job-title", Name = RouteNames.Onboarding.CurrentJobTitle)]
-[RequiredSessionModel(typeof(OnboardingSessionModel))]
 [Authorize]
 public class CurrentJobTitleController : Controller
 {

--- a/src/SFA.DAS.ApprenticeAan.Web/Controllers/Onboarding/EmployerDetailsController.cs
+++ b/src/SFA.DAS.ApprenticeAan.Web/Controllers/Onboarding/EmployerDetailsController.cs
@@ -4,7 +4,6 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.ApprenticeAan.Domain.Constants;
 using SFA.DAS.ApprenticeAan.Domain.Interfaces;
-using SFA.DAS.ApprenticeAan.Web.Filters;
 using SFA.DAS.ApprenticeAan.Web.Infrastructure;
 using SFA.DAS.ApprenticeAan.Web.Models;
 using SFA.DAS.ApprenticeAan.Web.Models.Onboarding;
@@ -13,7 +12,6 @@ namespace SFA.DAS.ApprenticeAan.Web.Controllers.Onboarding;
 
 [Authorize]
 [Route("onboarding/employer-details", Name = RouteNames.Onboarding.EmployerDetails)]
-[RequiredSessionModel(typeof(OnboardingSessionModel))]
 public class EmployerDetailsController : Controller
 {
     public const string ViewPath = "~/Views/Onboarding/EmployerDetails.cshtml";

--- a/src/SFA.DAS.ApprenticeAan.Web/Controllers/Onboarding/EmployerSearchController.cs
+++ b/src/SFA.DAS.ApprenticeAan.Web/Controllers/Onboarding/EmployerSearchController.cs
@@ -4,7 +4,6 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.ApprenticeAan.Domain.Constants;
 using SFA.DAS.ApprenticeAan.Domain.Interfaces;
-using SFA.DAS.ApprenticeAan.Web.Filters;
 using SFA.DAS.ApprenticeAan.Web.Infrastructure;
 using SFA.DAS.ApprenticeAan.Web.Models;
 using SFA.DAS.ApprenticeAan.Web.Models.Onboarding;
@@ -13,7 +12,6 @@ namespace SFA.DAS.ApprenticeAan.Web.Controllers.Onboarding;
 
 [Authorize]
 [Route("onboarding/employer-search", Name = RouteNames.Onboarding.EmployerSearch)]
-[RequiredSessionModel(typeof(OnboardingSessionModel))]
 public class EmployerSearchController : Controller
 {
     public const string ViewPath = "~/Views/Onboarding/EmployerSearch.cshtml";

--- a/src/SFA.DAS.ApprenticeAan.Web/Controllers/Onboarding/LineManagerController.cs
+++ b/src/SFA.DAS.ApprenticeAan.Web/Controllers/Onboarding/LineManagerController.cs
@@ -4,7 +4,7 @@ using FluentValidation.Results;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.ApprenticeAan.Domain.Interfaces;
-using SFA.DAS.ApprenticeAan.Web.Filters;
+using SFA.DAS.ApprenticeAan.Web.Configuration;
 using SFA.DAS.ApprenticeAan.Web.Infrastructure;
 using SFA.DAS.ApprenticeAan.Web.Models;
 using SFA.DAS.ApprenticeAan.Web.Models.Onboarding;
@@ -13,7 +13,6 @@ namespace SFA.DAS.ApprenticeAan.Web.Controllers.Onboarding;
 
 [Authorize]
 [Route("onboarding/line-manager", Name = RouteNames.Onboarding.LineManager)]
-[RequiredSessionModel(typeof(OnboardingSessionModel))]
 public class LineManagerController : Controller
 {
     public const string ViewPath = "~/Views/Onboarding/LineManager.cshtml";

--- a/src/SFA.DAS.ApprenticeAan.Web/Controllers/Onboarding/PreviousEngagementController.cs
+++ b/src/SFA.DAS.ApprenticeAan.Web/Controllers/Onboarding/PreviousEngagementController.cs
@@ -5,7 +5,6 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.ApprenticeAan.Domain.Constants;
 using SFA.DAS.ApprenticeAan.Domain.Interfaces;
-using SFA.DAS.ApprenticeAan.Web.Filters;
 using SFA.DAS.ApprenticeAan.Web.Infrastructure;
 using SFA.DAS.ApprenticeAan.Web.Models;
 using SFA.DAS.ApprenticeAan.Web.Models.Onboarding;
@@ -14,7 +13,6 @@ namespace SFA.DAS.ApprenticeAan.Web.Controllers.Onboarding;
 
 [Authorize]
 [Route("onboarding/previous-engagement", Name = RouteNames.Onboarding.PreviousEngagement)]
-[RequiredSessionModel(typeof(OnboardingSessionModel))]
 public class PreviousEngagementController : Controller
 {
     public const string ViewPath = "~/Views/Onboarding/PreviousEngagement.cshtml";

--- a/src/SFA.DAS.ApprenticeAan.Web/Controllers/Onboarding/ReasonToJoinController.cs
+++ b/src/SFA.DAS.ApprenticeAan.Web/Controllers/Onboarding/ReasonToJoinController.cs
@@ -4,7 +4,6 @@ using FluentValidation.Results;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.ApprenticeAan.Domain.Interfaces;
-using SFA.DAS.ApprenticeAan.Web.Filters;
 using SFA.DAS.ApprenticeAan.Web.Infrastructure;
 using SFA.DAS.ApprenticeAan.Web.Models;
 using SFA.DAS.ApprenticeAan.Web.Models.Onboarding;
@@ -13,7 +12,6 @@ namespace SFA.DAS.ApprenticeAan.Web.Controllers.Onboarding;
 
 [Authorize]
 [Route("onboarding/reason-to-join", Name = RouteNames.Onboarding.ReasonToJoin)]
-[RequiredSessionModel(typeof(OnboardingSessionModel))]
 public class ReasonToJoinController : Controller
 {
     public const string ViewPath = "~/Views/Onboarding/ReasonToJoin.cshtml";

--- a/src/SFA.DAS.ApprenticeAan.Web/Controllers/Onboarding/RegionsController.cs
+++ b/src/SFA.DAS.ApprenticeAan.Web/Controllers/Onboarding/RegionsController.cs
@@ -1,10 +1,9 @@
 ﻿using FluentValidation;
 using FluentValidation.AspNetCore;
-using Microsoft.AspNetCore.Authorization;
 using FluentValidation.Results;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.ApprenticeAan.Domain.Interfaces;
-using SFA.DAS.ApprenticeAan.Web.Filters;
 using SFA.DAS.ApprenticeAan.Web.Infrastructure;
 using SFA.DAS.ApprenticeAan.Web.Models;
 using SFA.DAS.ApprenticeAan.Web.Models.Onboarding;
@@ -13,7 +12,6 @@ namespace SFA.DAS.ApprenticeAan.Web.Controllers.Onboarding;
 
 [Authorize]
 [Route("onboarding/regions", Name = RouteNames.Onboarding.Regions)]
-[RequiredSessionModel(typeof(OnboardingSessionModel))]
 public class RegionsController : Controller
 {
     public const string ViewPath = "~/Views/Onboarding/Regions.cshtml";

--- a/src/SFA.DAS.ApprenticeAan.Web/Controllers/Onboarding/TermsAndConditionsController.cs
+++ b/src/SFA.DAS.ApprenticeAan.Web/Controllers/Onboarding/TermsAndConditionsController.cs
@@ -1,26 +1,15 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using SFA.DAS.ApprenticeAan.Domain.Interfaces;
-using SFA.DAS.ApprenticeAan.Web.Filters;
 using SFA.DAS.ApprenticeAan.Web.Infrastructure;
-using SFA.DAS.ApprenticeAan.Web.Models;
 using SFA.DAS.ApprenticeAan.Web.Models.Onboarding;
 
 namespace SFA.DAS.ApprenticeAan.Web.Controllers.Onboarding;
 
 [Authorize]
 [Route("onboarding/terms-and-conditions", Name = RouteNames.Onboarding.TermsAndConditions)]
-[RequiredSessionModel(typeof(OnboardingSessionModel))]
 public class TermsAndConditionsController : Controller
 {
     public const string ViewPath = "~/Views/Onboarding/TermsAndConditions.cshtml";
-
-    private readonly ISessionService _sessionService;
-
-    public TermsAndConditionsController(ISessionService sessionService)
-    {
-        _sessionService = sessionService;
-    }
 
     [HttpGet]
     public IActionResult Get()
@@ -35,10 +24,7 @@ public class TermsAndConditionsController : Controller
     [HttpPost]
     public IActionResult Post()
     {
-        var sessionModel = _sessionService.Get<OnboardingSessionModel>();
-        sessionModel.HasAcceptedTermsAndConditions = true;
-        _sessionService.Set(sessionModel);
-
+        if (!TempData.ContainsKey(TempDataKeys.HasSeenTermsAndConditions)) TempData.Add(TempDataKeys.HasSeenTermsAndConditions, true);
         return RedirectToRoute(RouteNames.Onboarding.LineManager);
     }
 }

--- a/src/SFA.DAS.ApprenticeAan.Web/Infrastructure/TempDataKeys.cs
+++ b/src/SFA.DAS.ApprenticeAan.Web/Infrastructure/TempDataKeys.cs
@@ -1,0 +1,6 @@
+﻿namespace SFA.DAS.ApprenticeAan.Web.Infrastructure;
+
+public static class TempDataKeys
+{
+    public const string HasSeenTermsAndConditions = nameof(HasSeenTermsAndConditions);
+}

--- a/src/SFA.DAS.ApprenticeAan.Web/Infrastructure/TempDataKeys.cs
+++ b/src/SFA.DAS.ApprenticeAan.Web/Infrastructure/TempDataKeys.cs
@@ -1,5 +1,8 @@
-﻿namespace SFA.DAS.ApprenticeAan.Web.Infrastructure;
+﻿using System.Diagnostics.CodeAnalysis;
 
+namespace SFA.DAS.ApprenticeAan.Web.Infrastructure;
+
+[ExcludeFromCodeCoverage]
 public static class TempDataKeys
 {
     public const string HasSeenTermsAndConditions = nameof(HasSeenTermsAndConditions);

--- a/src/SFA.DAS.ApprenticeAan.Web/Models/Onboarding/ShutterPageViewModel.cs
+++ b/src/SFA.DAS.ApprenticeAan.Web/Models/Onboarding/ShutterPageViewModel.cs
@@ -1,0 +1,6 @@
+﻿namespace SFA.DAS.ApprenticeAan.Web.Models.Onboarding;
+
+public class ShutterPageViewModel
+{
+    public string ApprenticeHomeUrl { get; set; } = null!;
+}

--- a/src/SFA.DAS.ApprenticeAan.Web/Models/OnboardingSessionModel.cs
+++ b/src/SFA.DAS.ApprenticeAan.Web/Models/OnboardingSessionModel.cs
@@ -4,14 +4,11 @@ public class OnboardingSessionModel
 {
     public bool HasSeenPreview { get; set; }
     public ApprenticeDetailsModel ApprenticeDetails { get; set; } = new ApprenticeDetailsModel();
-    public bool HasAcceptedTermsAndConditions { get; set; } = false;
-    public bool? HasEmployersApproval { get; set; }
+    public bool HasAcceptedTerms { get; set; } = false;
     public List<ProfileModel> ProfileData { get; set; } = new List<ProfileModel>();
     public int? RegionId { get; set; }
-    public bool IsValid =>
-        ApprenticeDetails.ApprenticeId.GetValueOrDefault() != Guid.Empty &&
-        HasAcceptedTermsAndConditions && HasEmployersApproval.GetValueOrDefault() &&
-        ProfileData.Count > 0;
+
+    public bool IsValid => HasAcceptedTerms && ProfileData.Count > 0;
 
     public string? GetProfileValue(int id) => ProfileData.Single(p => p.Id == id)?.Value;
 

--- a/src/SFA.DAS.ApprenticeAan.Web/Startup.cs
+++ b/src/SFA.DAS.ApprenticeAan.Web/Startup.cs
@@ -72,8 +72,9 @@ public class Startup
             .Configure<RouteOptions>(options => { options.LowercaseUrls = true; })
             .AddMvc(options =>
             {
-                options.Filters.Add(new AutoValidateAntiforgeryTokenAttribute());
+                options.Filters.Add(new RequiredSessionModelAttribute());
                 options.Filters.Add<RequiresRegistrationAuthorizationFilter>();
+                options.Filters.Add(new AutoValidateAntiforgeryTokenAttribute());
             })
             .AddSessionStateTempDataProvider();
 

--- a/src/SFA.DAS.ApprenticeAan.Web/Validators/Onboarding/LineManagerSubmitModelValidator.cs
+++ b/src/SFA.DAS.ApprenticeAan.Web/Validators/Onboarding/LineManagerSubmitModelValidator.cs
@@ -6,15 +6,12 @@ namespace SFA.DAS.ApprenticeAan.Web.Validators.Onboarding;
 public class LineManagerSubmitModelValidator : AbstractValidator<LineManagerSubmitModel>
 {
     public const string NoSelectionErrorMessage = "Tell us if you have approval from your line manager to join the network.";
-    public const string NoApprovalErrorMessage = "You must have your manager's approval before you complete and submit your application.";
 
     public LineManagerSubmitModelValidator()
     {
         RuleLevelCascadeMode = CascadeMode.Stop;
         RuleFor(m => m.HasEmployersApproval)
             .NotNull()
-            .WithMessage(NoSelectionErrorMessage)
-            .Equal(true)
-            .WithMessage(NoApprovalErrorMessage);
+            .WithMessage(NoSelectionErrorMessage);
     }
 }

--- a/src/SFA.DAS.ApprenticeAan.Web/Views/Onboarding/ShutterPage.cshtml
+++ b/src/SFA.DAS.ApprenticeAan.Web/Views/Onboarding/ShutterPage.cshtml
@@ -7,7 +7,7 @@
     <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-l">You do not meet the necessary criteria to join the network as an apprentice ambassador</h1>
         <div id="backtohomepage-hint" class="govuk-hint">
-            You must have your line manager's approval before you complete and submit your application
+            You must have your line manager's approval before completing your application.
         </div>
         <p class="govuk-body">
             <a href="@Model.ApprenticeHomeUrl" class="govuk-link govuk-link--no-visited-state">

--- a/src/SFA.DAS.ApprenticeAan.Web/Views/Onboarding/ShutterPage.cshtml
+++ b/src/SFA.DAS.ApprenticeAan.Web/Views/Onboarding/ShutterPage.cshtml
@@ -1,0 +1,18 @@
+﻿@using SFA.DAS.ApprenticeAan.Web.Models.Onboarding
+@model ShutterPageViewModel
+@{
+    ViewData["Title"] = "Shutter Page";
+}
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l">You do not meet the necessary criteria to join the network as an apprentice ambassador</h1>
+        <div id="backtohomepage-hint" class="govuk-hint">
+            You must have your line manager's approval before you complete and submit your application
+        </div>
+        <p class="govuk-body">
+            <a href="@Model.ApprenticeHomeUrl" class="govuk-link govuk-link--no-visited-state">
+                Back to the apprenticeship portal
+            </a>
+        </p>
+    </div>
+</div>


### PR DESCRIPTION
The required session model filter is now applied conventionally instead of being on each controller, this allows more control over the attribute and reduces impact heavily. The attribute now checks if the session model is valid or not. 
I have moved initialization of session model in LineManagerController as the journey only starts if there is line manager approval. As a result the before you start and terms and conditions controller have been simplified. 
Onboarding session model now has only one HasAgreedTerms flag which is set to true if there is positive answer to line manager's approval question. 
