### PR TITLE
CSP-840 enum for EventFormat added

### DIFF
--- a/src/SFA.DAS.ApprenticeAan.Domain/Constants/EventFormat.cs
+++ b/src/SFA.DAS.ApprenticeAan.Domain/Constants/EventFormat.cs
@@ -1,12 +1,13 @@
-﻿
-using System.Diagnostics.CodeAnalysis;
+﻿using System.ComponentModel;
 
 namespace SFA.DAS.ApprenticeAan.Domain.Constants;
 
-[ExcludeFromCodeCoverage]
-public static class EventFormat
+public enum EventFormat
 {
-    public const string Hybrid = "hybrid";
-    public const string InPerson = "in person";
-    public const string Online = "online";
+    [Description("In person")]
+    InPerson,
+    [Description("Online")]
+    Online,
+    [Description("Hybrid")]
+    Hybrid
 }

--- a/src/SFA.DAS.ApprenticeAan.Web/Views/NetworkEvents/Index.cshtml
+++ b/src/SFA.DAS.ApprenticeAan.Web/Views/NetworkEvents/Index.cshtml
@@ -279,12 +279,12 @@
                                 <dd class="das-definition-list__definition">@calendarEvent.Start.ToString("h:mmtt").ToLower() - @calendarEvent.End.ToString("h:mmtt").ToLower()</dd>
                                 <dt class="das-definition-list__title">Where</dt>
                                 <dd class="das-definition-list__definition">@calendarEvent.Location 
-                                    @if (calendarEvent.EventFormat != EventFormat.Online && calendarEvent.Latitude != null && calendarEvent.Longitude != null)
+                                    @if (calendarEvent.EventFormat != "Online" && calendarEvent.Latitude != null && calendarEvent.Longitude != null)
                                     {
                                         <a href="https://www.google.com/maps/dir/@calendarEvent.Latitude,@calendarEvent.Longitude" rel="noopener" target="_blank" class="govuk-link">(view map in a new window)</a>
                                     }
                                 </dd>
-                                @if (calendarEvent.EventFormat != EventFormat.Online && calendarEvent.Distance != null)
+                                @if (calendarEvent.EventFormat != "Online" && calendarEvent.Distance != null)
                                 {
                                     <dt class="das-definition-list__title">Distance</dt>
                                     <dd class="das-definition-list__definition">@calendarEvent.Distance?.ToString("0.0") miles</dd>

--- a/src/SFA.DAS.ApprenticeAan.Web/Views/Shared/_EventFormat.cshtml
+++ b/src/SFA.DAS.ApprenticeAan.Web/Views/Shared/_EventFormat.cshtml
@@ -2,13 +2,13 @@
 
 @switch (Model)
 {
-    case EventFormat.InPerson:
+    case "InPerson":
         <strong class="govuk-tag app-tag app-tag--inperson">In person</strong>
         break;
-    case EventFormat.Hybrid:
+    case "Hybrid":
         <strong class="govuk-tag app-tag app-tag--hybrid">Hybrid</strong>
         break;
-    case EventFormat.Online:
+    case "Online":
         <strong class="govuk-tag app-tag app-tag--online">Online</strong>
         break;
 }


### PR DESCRIPTION
This is to inject a common enum for EventFormat (replacing a class with const strings).  As a temporary measure, all references to the original strings is now replaced with inline strings, and this will be cleaned up in next story CSP-731, but this needs merging  before I can finally clean up CSP-731 and progress it to RTT