### PR TITLE
CSP-1309: Apprentice Details Sync When Logging Into AAN

### DIFF
--- a/src/SFA.DAS.ApprenticeAan.Application.UnitTests/Services/MemberServiceTests.cs
+++ b/src/SFA.DAS.ApprenticeAan.Application.UnitTests/Services/MemberServiceTests.cs
@@ -1,0 +1,46 @@
+﻿using Moq;
+using SFA.DAS.ApprenticeAan.Application.Services;
+using SFA.DAS.ApprenticeAan.Domain.Interfaces;
+using SFA.DAS.ApprenticeAan.Domain.OuterApi.Requests;
+using SFA.DAS.Testing.AutoFixture;
+
+namespace SFA.DAS.ApprenticeAan.Application.UnitTests.Services
+{
+    public class MemberServiceTests
+    {
+        [Test]
+        [MoqAutoData]
+        public async Task UpdateMemberDetails_InvokesApiClient(
+            Mock<IOuterApiClient> clientMock,
+            Guid apprenticeId,
+            string firstName,
+            string lastName,
+            CancellationToken cancellationToken
+        )
+        {
+            var updateMemberProfileRequest = new UpdateMemberProfileAndPreferencesRequest
+            {
+                PatchMemberRequest = new PatchMemberRequest
+                {
+                    FirstName = firstName,
+                    LastName = lastName
+                }
+            };
+
+            clientMock.Setup(a => a.UpdateMemberProfileAndPreferences(
+                apprenticeId,
+                It.Is<UpdateMemberProfileAndPreferencesRequest>(request =>
+                    request.PatchMemberRequest.FirstName == updateMemberProfileRequest.PatchMemberRequest.FirstName &&
+                    request.PatchMemberRequest.LastName == updateMemberProfileRequest.PatchMemberRequest.LastName
+                ),
+                cancellationToken)
+            ).Verifiable();
+
+            MemberService sut = new MemberService(clientMock.Object);
+
+            await sut.UpdateMemberDetails(apprenticeId, firstName, lastName, cancellationToken);
+
+            clientMock.Verify();
+        }
+    }
+}

--- a/src/SFA.DAS.ApprenticeAan.Application/Services/MemberService.cs
+++ b/src/SFA.DAS.ApprenticeAan.Application/Services/MemberService.cs
@@ -1,0 +1,28 @@
+﻿using SFA.DAS.ApprenticeAan.Domain.Interfaces;
+using SFA.DAS.ApprenticeAan.Domain.OuterApi.Requests;
+
+namespace SFA.DAS.ApprenticeAan.Application.Services
+{
+    public class MemberService : IMemberService
+    {
+        private readonly IOuterApiClient _client;
+
+        public MemberService(IOuterApiClient client)
+        {
+            _client = client;
+        }
+
+        public async Task UpdateMemberDetails(Guid apprenticeId, string firstName, string lastName, CancellationToken cancellationToken)
+        {
+            UpdateMemberProfileAndPreferencesRequest updateMemberProfileRequest = new()
+            {
+                PatchMemberRequest = new PatchMemberRequest()
+                {
+                    FirstName = firstName,
+                    LastName = lastName
+                }
+            };
+            await _client.UpdateMemberProfileAndPreferences(apprenticeId, updateMemberProfileRequest, cancellationToken);
+        }
+    }
+}

--- a/src/SFA.DAS.ApprenticeAan.Domain/Interfaces/IMemberService.cs
+++ b/src/SFA.DAS.ApprenticeAan.Domain/Interfaces/IMemberService.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace SFA.DAS.ApprenticeAan.Domain.Interfaces
+{
+    public interface IMemberService
+    {
+        Task UpdateMemberDetails(Guid apprenticeId, string firstName, string lastName, CancellationToken cancellationToken);
+    }
+}

--- a/src/SFA.DAS.ApprenticeAan.Domain/Interfaces/IOuterApiClient.cs
+++ b/src/SFA.DAS.ApprenticeAan.Domain/Interfaces/IOuterApiClient.cs
@@ -1,7 +1,10 @@
-﻿using RestEase;
+﻿using Microsoft.AspNetCore.JsonPatch;
+using Microsoft.AspNetCore.Mvc;
+using RestEase;
 using SFA.DAS.Aan.SharedUi.Constants;
 using SFA.DAS.Aan.SharedUi.Models.LeaveTheNetwork;
 using SFA.DAS.Aan.SharedUi.OuterApi.Responses;
+using SFA.DAS.ApprenticeAan.Domain.OuterApi.Entities;
 using SFA.DAS.ApprenticeAan.Domain.OuterApi.Requests;
 using SFA.DAS.ApprenticeAan.Domain.OuterApi.Responses;
 
@@ -72,12 +75,14 @@ public interface IOuterApiClient
     [Get("/members/{memberId}/profile")]
     Task<GetMemberProfileResponse> GetMemberProfile([Path] Guid memberId, [Header(RequestHeaders.RequestedByMemberIdHeader)] Guid requestedByMemberId, [Query] bool @public, CancellationToken cancellationToken);
 
+    [Patch("members/{memberId}")]
+    Task<IActionResult> PatchMember([Path] Guid memberId, JsonPatchDocument<Member> request, CancellationToken cancellationToken);
+
     [Post("/notifications")]
     Task<CreateNotificationResponse> PostNotification([Header(RequestHeaders.RequestedByMemberIdHeader)] Guid requestedByMemberId, [Body] CreateNotificationRequest request, CancellationToken cancellationToken);
 
     [Put("/members/{memberId}")]
     Task UpdateMemberProfileAndPreferences([Path] Guid memberId, [Body] UpdateMemberProfileAndPreferencesRequest request, CancellationToken cancellationToken);
-
 
     [Get("/LeavingReasons")]
     Task<List<LeavingCategory>> GetLeavingReasons();

--- a/src/SFA.DAS.ApprenticeAan.Domain/OuterApi/Entities/Member.cs
+++ b/src/SFA.DAS.ApprenticeAan.Domain/OuterApi/Entities/Member.cs
@@ -1,0 +1,19 @@
+﻿namespace SFA.DAS.ApprenticeAan.Domain.OuterApi.Entities
+{
+    public class Member
+    {
+        public Guid Id { get; set; }
+        //public UserType UserType { get; set; }
+        public string Email { get; set; } = null!;
+        public string FirstName { get; set; } = null!;
+        public string LastName { get; set; } = null!;
+        public string Status { get; set; } = null!;
+        public DateTime JoinedDate { get; set; }
+        public int? RegionId { get; set; }
+        public string? OrganisationName { get; set; }
+        public DateTime? EndDate { get; set; }
+        public DateTime LastUpdatedDate { get; set; }
+        public bool? IsRegionalChair { get; set; }
+        public string FullName { get; set; } = null!;
+    }
+}

--- a/src/SFA.DAS.ApprenticeAan.Domain/OuterApi/Entities/Member.cs
+++ b/src/SFA.DAS.ApprenticeAan.Domain/OuterApi/Entities/Member.cs
@@ -1,9 +1,11 @@
-﻿namespace SFA.DAS.ApprenticeAan.Domain.OuterApi.Entities
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace SFA.DAS.ApprenticeAan.Domain.OuterApi.Entities
 {
+    [ExcludeFromCodeCoverage]
     public class Member
     {
         public Guid Id { get; set; }
-        //public UserType UserType { get; set; }
         public string Email { get; set; } = null!;
         public string FirstName { get; set; } = null!;
         public string LastName { get; set; } = null!;

--- a/src/SFA.DAS.ApprenticeAan.Domain/OuterApi/Requests/UpdateMemberProfileAndPreferencesRequest.cs
+++ b/src/SFA.DAS.ApprenticeAan.Domain/OuterApi/Requests/UpdateMemberProfileAndPreferencesRequest.cs
@@ -11,6 +11,8 @@ public class PatchMemberRequest
 {
     public int RegionId { get; set; }
     public string? OrganisationName { get; set; }
+    public string? FirstName { get; set; }
+    public string? LastName { get; set; }
 }
 
 public class UpdateMemberProfileRequest

--- a/src/SFA.DAS.ApprenticeAan.Domain/SFA.DAS.ApprenticeAan.Domain.csproj
+++ b/src/SFA.DAS.ApprenticeAan.Domain/SFA.DAS.ApprenticeAan.Domain.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="8.0.3" />
     <PackageReference Include="SFA.DAS.ApprenticePortal.SharedUi" Version="1.1.72" />
     <PackageReference Include="RestEase" Version="1.6.4" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.3.1" />

--- a/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Helpers/ClaimsHelperTests.cs
+++ b/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Helpers/ClaimsHelperTests.cs
@@ -18,7 +18,7 @@ namespace SFA.DAS.ApprenticeAan.Web.UnitTests.Helpers
 
             var isClaimsMismatch = ClaimsHelper.IsClaimsMismatch(apprentice, claimsPrincipal);
 
-            Assert.True(isClaimsMismatch);
+            Assert.That(isClaimsMismatch, Is.True);
         }
 
         [Test]
@@ -31,7 +31,7 @@ namespace SFA.DAS.ApprenticeAan.Web.UnitTests.Helpers
 
             var isClaimsMismatch = ClaimsHelper.IsClaimsMismatch(apprentice, claimsPrincipal);
 
-            Assert.True(isClaimsMismatch);
+            Assert.That(isClaimsMismatch, Is.True);
         }
 
         [Test]
@@ -44,7 +44,7 @@ namespace SFA.DAS.ApprenticeAan.Web.UnitTests.Helpers
 
             var claimValues = ClaimsHelper.QueryClaimsByType(IdentityClaims.GivenName, claimsPrincipal.Claims);
 
-            Assert.Contains(nameof(IdentityClaims.GivenName), claimValues);
+            Assert.That(claimValues, Does.Contain(nameof(IdentityClaims.GivenName)));
         }
 
         [Test]

--- a/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Helpers/ClaimsHelperTests.cs
+++ b/src/SFA.DAS.ApprenticeAan.Web.UnitTests/Helpers/ClaimsHelperTests.cs
@@ -1,0 +1,82 @@
+﻿using AutoFixture.NUnit3;
+using SFA.DAS.ApprenticeAan.Domain.OuterApi.Responses;
+using SFA.DAS.ApprenticeAan.Web.Helpers;
+using SFA.DAS.ApprenticePortal.Authentication;
+using System.Security.Claims;
+
+namespace SFA.DAS.ApprenticeAan.Web.UnitTests.Helpers
+{
+    public class ClaimsHelperTests
+    {
+        [Test]
+        [AutoData]
+        public void IsClaimsMismatch_ReturnsMisMatchOnGivenName(Apprentice apprentice)
+        {
+            apprentice.LastName = nameof(IdentityClaims.FamilyName);
+
+            var claimsPrincipal = CreateClaimsPrinciple();
+
+            var isClaimsMismatch = ClaimsHelper.IsClaimsMismatch(apprentice, claimsPrincipal);
+
+            Assert.True(isClaimsMismatch);
+        }
+
+        [Test]
+        [AutoData]
+        public void IsClaimsMismatch_ReturnsMisMatchOnLastName(Apprentice apprentice)
+        {
+            apprentice.FirstName = nameof(IdentityClaims.GivenName);
+
+            var claimsPrincipal = CreateClaimsPrinciple();
+
+            var isClaimsMismatch = ClaimsHelper.IsClaimsMismatch(apprentice, claimsPrincipal);
+
+            Assert.True(isClaimsMismatch);
+        }
+
+        [Test]
+        [AutoData]
+        public void QueryClaimsByType_ReturnsCorrectType(Apprentice apprentice)
+        {
+            apprentice.FirstName = nameof(IdentityClaims.GivenName);
+
+            var claimsPrincipal = CreateClaimsPrinciple();
+
+            var claimValues = ClaimsHelper.QueryClaimsByType(IdentityClaims.GivenName, claimsPrincipal.Claims);
+
+            Assert.Contains(nameof(IdentityClaims.GivenName), claimValues);
+        }
+
+        [Test]
+        [AutoData]
+        public void GetMismatchValue_ReturnsMisMatchOnGivenName(Apprentice apprentice)
+        {
+            var claimsPrincipal = CreateClaimsPrinciple();
+
+            var mismatchValue = ClaimsHelper.GetMismatchValue(apprentice.FirstName, claimsPrincipal, IdentityClaims.GivenName);
+
+            Assert.That(mismatchValue ?? string.Empty, Is.EqualTo(nameof(IdentityClaims.GivenName)));
+        }
+
+        private static ClaimsPrincipal CreateClaimsPrinciple(bool excludeGivenName = false, bool excludeFamilyName = false)
+        {
+            List<Claim> claims = new List<Claim>();
+
+            if(!excludeGivenName)
+            {
+                claims.Add(new(IdentityClaims.GivenName, nameof(IdentityClaims.GivenName)));
+            }
+
+            if (!excludeGivenName)
+            {
+                claims.Add(new(IdentityClaims.FamilyName, nameof(IdentityClaims.FamilyName)));
+            }
+
+            ClaimsPrincipal claimsPrincipal = new();
+
+            claimsPrincipal.AddIdentity(new ClaimsIdentity(claims));
+
+            return claimsPrincipal;
+        }
+    }
+}

--- a/src/SFA.DAS.ApprenticeAan.Web/AppStart/AddServiceRegistrationsExtension.cs
+++ b/src/SFA.DAS.ApprenticeAan.Web/AppStart/AddServiceRegistrationsExtension.cs
@@ -20,6 +20,7 @@ public static class ServiceRegistrationsStartup
         services.AddTransient<IRegionService, RegionService>();
         services.AddTransient<IApprenticeAccountService, ApprenticeAccountService>();
         services.AddTransient<IApprenticeService, ApprenticeService>();
+        services.AddTransient<IMemberService, MemberService>();
         return services;
     }
 

--- a/src/SFA.DAS.ApprenticeAan.Web/Helpers/ClaimsHelper.cs
+++ b/src/SFA.DAS.ApprenticeAan.Web/Helpers/ClaimsHelper.cs
@@ -1,0 +1,31 @@
+﻿using SFA.DAS.ApprenticeAan.Domain.OuterApi.Responses;
+using SFA.DAS.ApprenticePortal.Authentication;
+using System.Security.Claims;
+
+namespace SFA.DAS.ApprenticeAan.Web.Helpers
+{
+    public static class ClaimsHelper
+    {
+        public static bool IsClaimsMismatch(Apprentice apprentice, ClaimsPrincipal claimPrincipal)
+        {
+            return CheckValueMismatch(apprentice.FirstName, QueryClaimsByType(IdentityClaims.GivenName, claimPrincipal.Claims)) ||
+
+                 CheckValueMismatch(apprentice.LastName, QueryClaimsByType(IdentityClaims.FamilyName, claimPrincipal.Claims));
+        }
+
+        public static string[] QueryClaimsByType(string type, IEnumerable<Claim> claims)
+        {
+            return claims.Where(a => a.Type == type).Select(a => a.Value).ToArray();
+        }
+
+        private static bool CheckValueMismatch(string apprenticeValue, string[] identityValues)
+        {
+            return identityValues.Any(a => !string.Equals(a, apprenticeValue, StringComparison.Ordinal));
+        }
+
+        public static string? GetMismatchValue(string apprenticeValue, ClaimsPrincipal claimPrincipal, string claimType)
+        {
+            return QueryClaimsByType(claimType, claimPrincipal.Claims).FirstOrDefault(a => !string.Equals(a, apprenticeValue, StringComparison.Ordinal));
+        }
+    }
+}

--- a/src/SFA.DAS.ApprenticeAan.Web/Helpers/ClaimsHelper.cs
+++ b/src/SFA.DAS.ApprenticeAan.Web/Helpers/ClaimsHelper.cs
@@ -20,7 +20,7 @@ namespace SFA.DAS.ApprenticeAan.Web.Helpers
 
         private static bool CheckValueMismatch(string apprenticeValue, string[] identityValues)
         {
-            return identityValues.Any(a => !string.Equals(a, apprenticeValue, StringComparison.Ordinal));
+            return Array.Exists(identityValues, a => !string.Equals(a, apprenticeValue, StringComparison.Ordinal));
         }
 
         public static string? GetMismatchValue(string apprenticeValue, ClaimsPrincipal claimPrincipal, string claimType)

--- a/src/SFA.DAS.ApprenticeAan.Web/Helpers/ClaimsHelper.cs
+++ b/src/SFA.DAS.ApprenticeAan.Web/Helpers/ClaimsHelper.cs
@@ -25,7 +25,7 @@ namespace SFA.DAS.ApprenticeAan.Web.Helpers
 
         public static string? GetMismatchValue(string apprenticeValue, ClaimsPrincipal claimPrincipal, string claimType)
         {
-            return QueryClaimsByType(claimType, claimPrincipal.Claims).FirstOrDefault(a => !string.Equals(a, apprenticeValue, StringComparison.Ordinal));
+            return QueryClaimsByType(claimType, claimPrincipal.Claims).LastOrDefault(a => !string.Equals(a, apprenticeValue, StringComparison.Ordinal));
         }
     }
 }


### PR DESCRIPTION
- Updated **RequiresExistingMemberAttribute** to handle an update to the user claims for given name and family name properties. The method selects the last updated claim per apprentice and updates the member entity.